### PR TITLE
Updated listCurrentOrders, listMarketBook, listMarketCatalogue and pl…

### DIFF
--- a/R/listCurrentOrders.R
+++ b/R/listCurrentOrders.R
@@ -62,9 +62,9 @@
 #'  that can be returned in one call. By default, this parameter is set to
 #'  FALSE, meaning this warning is not flagged. Changing this parameter to TRUE
 #'  will result in warnings being posted.
-#'  
-#'@param suppress Boolean. By default, this parameter is set to FALSE, meaning 
-#'  that a warning is posted when the listCurrentOrders call throws an error. 
+#'
+#'@param suppress Boolean. By default, this parameter is set to FALSE, meaning
+#'  that a warning is posted when the listCurrentOrders call throws an error.
 #'  Changing this parameter to TRUE will suppress this warning.
 #'
 #'@param sslVerify Boolean. This argument defaults to TRUE and is optional. In
@@ -83,9 +83,9 @@
 #'  variable is used to firstly build an R data frame containing all the data to
 #'  be passed to Betfair, in order for the function to execute successfully. The
 #'  data frame is then converted to JSON and included in the HTTP POST request.
-#'  If the listCurrentOrders call throws an error, a data frame containing error 
+#'  If the listCurrentOrders call throws an error, a data frame containing error
 #'  information is returned.
-#'  
+#'
 #' @examples
 #' \dontrun{
 #'  Return all current orders:
@@ -100,16 +100,16 @@ listCurrentOrders <-
            fromDate = NULL, toDate = NULL, flag = FALSE, orderProjectionValue = NULL,
            fromRecordValue = NULL, recordCountValue = NULL, suppress = FALSE, sslVerify = TRUE) {
     options(stringsAsFactors = FALSE)
-    
+
     listOrderOps <-
       data.frame(jsonrpc = "2.0", method = "SportsAPING/v1.0/listCurrentOrders", id = "1")
-    
+
     listOrderOps$params <- data.frame(orderProjection = "")
     if (!is.null(betIds))
       listOrderOps$params$betIds <- list(c(betIds))
     if (!is.null(marketIds))
       listOrderOps$params$marketIds <- list(c(marketIds))
-    
+
     listOrderOps$params$orderProjection <- orderProjectionValue
     listOrderOps$params$orderBy <- orderByValue
     listOrderOps$params$SortDir <- SortDirValue
@@ -118,35 +118,33 @@ listCurrentOrders <-
     if (!is.null(fromDate) & !is.null(toDate))
       listOrderOps$params$daterange <-
       data.frame(from = fromDate, to = toDate)
-    
+
     listOrderOps <-
       listOrderOps[c("jsonrpc", "method", "params", "id")]
-    
-    listOrderOps <- jsonlite::toJSON(listOrderOps, pretty = TRUE)
-    
+
+    listOrderOps <- jsonlite::toJSON(jsonlite::unbox(listOrderOps))
+
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
-    
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-    
-    listOrder <-
-      jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listOrderOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      )
-    
+
+    listOrder <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listOrderOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
+
+    listOrder <- jsonlite::fromJSON(listOrder)
+
+
     if (!is.null(listOrder$error)){
       if(!suppress)
         warning("Error- See output for details")
       return(as.data.frame(listOrder$error))}
-    if (listOrder$result$moreAvailable & flag == TRUE)
+    if (listOrder$result$moreAvailable && flag == TRUE)
       warning("Not all bets included in output- More bets available")
     as.data.frame(listOrder$result$currentOrders)
-    
+
   }

--- a/R/listMarketBook.R
+++ b/R/listMarketBook.R
@@ -152,24 +152,21 @@ listMarketBook <- function(marketIds, priceData , orderProjection = NULL,
     listMarketBookOps[c("jsonrpc", "method", "params", "id")]
 
   listMarketBookOps <-
-    jsonlite::toJSON(listMarketBookOps, pretty = TRUE)
+    jsonlite::toJSON(jsonlite::unbox(listMarketBookOps))
 
   # Read Environment variables for authorisation details
   product <- Sys.getenv('product')
   token <- Sys.getenv('token')
 
-  headers <- list(
-    'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-  )
+  listMarketBook <- httr::content(
+    httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+               config = httr::config(ssl_verifypeer = sslVerify),
+               body = listMarketBookOps,
+               httr::add_headers(Accept = "application/json",
+                                 "X-Application" = product,
+                                 "X-Authentication" = token)), as = "text")
 
-  listMarketBook <-
-    as.list(jsonlite::fromJSON(
-      RCurl::postForm(
-        "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-          postfields = listMarketBookOps, httpheader = headers, ssl.verifypeer = sslVerify
-        )
-      )
-    ))
+  listMarketBook <- jsonlite::fromJSON(listMarketBook)
 
   if(is.null(listMarketBook$error))
     as.data.frame(listMarketBook$result)

--- a/R/listMarketCatalogue.R
+++ b/R/listMarketCatalogue.R
@@ -108,9 +108,9 @@
 #'   wildcard (*) character as long as it is not the first character. Optional.
 #'   Default is NULL.
 #'
-#' @param suppress Boolean. By default, this parameter is set to FALSE, meaning 
-#'   that a warning is posted when the listMarketCatalogue call throws an error. 
-#'   Changing this parameter to TRUE will suppress this warning.   
+#' @param suppress Boolean. By default, this parameter is set to FALSE, meaning
+#'   that a warning is posted when the listMarketCatalogue call throws an error.
+#'   Changing this parameter to TRUE will suppress this warning.
 #'
 #' @param sslVerify Boolean. This argument defaults to TRUE and is optional. In
 #'   some cases, where users have a self signed SSL Certificate, for example
@@ -127,7 +127,7 @@
 #'   \code{listMarketCatalogueOps} variable is used to firstly build an R data
 #'   frame containing all the data to be passed to Betfair, in order for the
 #'   function to execute successfully. The data frame is then converted to JSON
-#'   and included in the HTTP POST request. If the listMarketCatalogue call throws 
+#'   and included in the HTTP POST request. If the listMarketCatalogue call throws
 #'   an error, a data frame containing error information is returned.
 #'
 #' @examples
@@ -168,98 +168,95 @@ listMarketCatalogue <-
                "COMPETITION", "EVENT", "EVENT_TYPE", "RUNNER_DESCRIPTION", "RUNNER_METADATA", "MARKET_START_TIME"
              ),textQuery = NULL, suppress = FALSE, sslVerify = TRUE) {
     options(stringsAsFactors = FALSE)
-    
+
     listMarketCatalogueOps <-
       data.frame(jsonrpc = "2.0", method = "SportsAPING/v1.0/listMarketCatalogue", id = "1")
-    
+
     listMarketCatalogueOps$params <-
       data.frame(filter = c(""), maxResults = c(maxResults))
     listMarketCatalogueOps$params$filter <-
       data.frame(marketStartTime = c(""))
     listMarketCatalogueOps$params$sort = marketSort
-    
+
     if (!is.null(eventIds)) {
       listMarketCatalogueOps$params$filter$eventIds <- list(eventIds)
     }
-    
+
     if (!is.null(eventTypeIds)) {
       listMarketCatalogueOps$params$filter$eventTypeIds <-
         list(eventTypeIds)
     }
-    
+
     if (!is.null(competitionIds)) {
       listMarketCatalogueOps$params$filter$competitionIds <-
         list(competitionIds)
     }
-    
+
     if (!is.null(marketIds)) {
       listMarketCatalogueOps$params$filter$marketIds <- list(marketIds)
     }
-    
+
     if (!is.null(venues)) {
       listMarketCatalogueOps$params$filter$venues <- list(venues)
     }
-    
+
     if (!is.null(marketCountries)) {
       listMarketCatalogueOps$params$filter$marketCountries <-
         list(marketCountries)
     }
-    
+
     if (!is.null(marketTypeCodes)) {
       listMarketCatalogueOps$params$filter$marketTypeCodes <-
         list(marketTypeCodes)
     }
-    
+
     listMarketCatalogueOps$params$filter$bspOnly <- bspOnly
     listMarketCatalogueOps$params$filter$turnInPlayEnabled <-
       turnInPlayEnabled
     listMarketCatalogueOps$params$filter$inPlayOnly <- inPlayOnly
     listMarketCatalogueOps$params$filter$textQuery <- textQuery
-    
+
     if (!is.null(marketBettingTypes)) {
       listMarketCatalogueOps$params$filter$marketBettingTypes <-
         list(marketBettingTypes)
     }
-    
+
     if (!is.null(withOrders)) {
       listMarketCatalogueOps$params$filter$withOrders <- list(withOrders)
     }
-    
+
     listMarketCatalogueOps$params$filter$marketStartTime <-
       data.frame(from = fromDate, to = toDate)
-    
+
     if (!is.null(marketProjection))  {
       listMarketCatalogueOps$params$marketProjection <-
         list(marketProjection)
     }
-    
+
     listMarketCatalogueOps <-
       listMarketCatalogueOps[c("jsonrpc", "method", "params", "id")]
-    
-    listMarketCatalogueOps <-
-      jsonlite::toJSON(listMarketCatalogueOps, pretty = TRUE)
-    
-    # Read Environment variables for authorisation details
-    product <- Sys.getenv('product')
-    token <- Sys.getenv('token')
-    
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-    
-    listMarketCatalogue <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listMarketCatalogueOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
-    
-    if(is.null(listMarketCatalogue$error))
-      as.data.frame(listMarketCatalogue$result)
-    else({
-      if(!suppress)
+
+    listMarketCatalogueOps <- jsonlite::toJSON(jsonlite::unbox(listMarketCatalogueOps))
+
+    product <- Sys.getenv("product")
+    token <- Sys.getenv("token")
+
+    listMarketCat <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listMarketCatalogueOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
+
+    listMarketCat <- jsonlite::fromJSON(listMarketCat)
+
+    if (is.null(listMarketCat$error))
+      as.data.frame(listMarketCat$result)
+    else ({
+      if (!suppress)
         warning("Error- See output for details")
-      as.data.frame(listMarketCatalogue$error)})
+      as.data.frame(listMarketCat$error)
+    })
+
   }


### PR DESCRIPTION
Updated listCurrentOrders, listMarketBook, listMarketCatalogue and placeOrders to use httr

Following Betfair switching off support for TLS 1.0, these functions no longer worked. They have been updated to work using httr which includes newer security protocols. 

These changes are the minimum required to make the functions work and no other changes have been made. 