### PR TITLE
Move from RCurl to httr for rest of the Betting API functions

### DIFF
--- a/R/listCompetitions.R
+++ b/R/listCompetitions.R
@@ -192,25 +192,22 @@ listCompetitions <-
       listCompetitionsOps[c("jsonrpc", "method", "params", "id")]
 
     listCompetitionsOps <-
-      jsonlite::toJSON(listCompetitionsOps, pretty = TRUE)
+      jsonlite::toJSON(jsonlite::unbox(listCompetitionsOps))
 
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
 
 
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
+    listCompetitions <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listCompetitionsOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
 
-    listCompetitions <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listCompetitionsOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
+    listCompetitions <- jsonlite::fromJSON(listCompetitions)
 
     if(is.null(listCompetitions$error))
       as.data.frame(listCompetitions$result[1])

--- a/R/listEventTypes.R
+++ b/R/listEventTypes.R
@@ -189,25 +189,21 @@ listEventTypes <-
       listEventTypesOps[c("jsonrpc", "method", "params", "id")]
 
     listEventTypesOps <-
-      jsonlite::toJSON(listEventTypesOps, pretty = TRUE)
+      jsonlite::toJSON(jsonlite::unbox(listEventTypesOps))
 
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
 
+    listEventTypes <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listEventTypesOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
 
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-
-    listEventTypes <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listEventTypesOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
+    listEventTypes <- jsonlite::fromJSON(listEventTypes)
 
     if(is.null(listEventTypes$error))
       as.data.frame(listEventTypes$result[1])

--- a/R/listEvents.R
+++ b/R/listEvents.R
@@ -205,25 +205,21 @@ listEvents <-
       listEventsOps[c("jsonrpc", "method", "params", "id")]
 
     listEventsOps <-
-      jsonlite::toJSON(listEventsOps, pretty = TRUE)
+      jsonlite::toJSON(jsonlite::unbox(listEventsOps))
 
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
 
+    listEvents <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listEventsOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
 
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-
-    listEvents <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listEventsOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
+    listEvents <- jsonlite::fromJSON(listEvents)
 
     if(is.null(listEvents$error))
       as.data.frame(listEvents$result[1])

--- a/R/listMarketTypes.R
+++ b/R/listMarketTypes.R
@@ -191,25 +191,21 @@ listMarketTypes <-
       listMarketTypesOps[c("jsonrpc", "method", "params", "id")]
 
     listMarketTypesOps <-
-      jsonlite::toJSON(listMarketTypesOps, pretty = TRUE)
+      jsonlite::toJSON(jsonlite::unbox(listMarketTypesOps))
 
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
 
+    listMarketTypes <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listMarketTypesOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
 
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-
-    listMarketTypes <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listMarketTypesOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
+    listMarketTypes <- jsonlite::fromJSON(listMarketTypes)
 
     if(is.null(listMarketTypes$error))
       as.data.frame(listMarketTypes$result[1])

--- a/R/listVenues.R
+++ b/R/listVenues.R
@@ -186,25 +186,21 @@ listVenues <-
       listVenuesOps[c("jsonrpc", "method", "params", "id")]
 
     listVenuesOps <-
-      jsonlite::toJSON(listVenuesOps, pretty = TRUE)
+      jsonlite::toJSON(jsonlite::unbox(listVenuesOps))
 
     # Read Environment variables for authorisation details
     product <- Sys.getenv('product')
     token <- Sys.getenv('token')
 
+    listVenues <- httr::content(
+      httr::POST(url = "https://api.betfair.com/exchange/betting/json-rpc/v1",
+                 config = httr::config(ssl_verifypeer = sslVerify),
+                 body = listVenuesOps,
+                 httr::add_headers(Accept = "application/json",
+                                   "X-Application" = product,
+                                   "X-Authentication" = token)), as = "text")
 
-    headers <- list(
-      'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-    )
-
-    listVenues <-
-      as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://api.betfair.com/exchange/betting/json-rpc/v1", .opts = list(
-            postfields = listVenuesOps, httpheader = headers, ssl.verifypeer = sslVerify
-          )
-        )
-      ))
+    listVenues <- jsonlite::fromJSON(listVenues)
 
     if(is.null(listVenues$error))
       as.data.frame(listVenues$result[1])

--- a/R/logoutBF.R
+++ b/R/logoutBF.R
@@ -13,9 +13,9 @@
 #' @seealso \code{\link{loginBF}}, which must be executed first, as this
 #'   function requires a valid session token
 #'
-#' @param suppress Boolean. \code{RCurl::postForm} posts a warning due to a 
-#'   lack of inputs. By default, this parameter is set to TRUE, meaning this 
-#'   warning is suppressed. Changing this parameter to FALSE will result in warnings 
+#' @param suppress Boolean. \code{RCurl::postForm} posts a warning due to a
+#'   lack of inputs. By default, this parameter is set to TRUE, meaning this
+#'   warning is suppressed. Changing this parameter to FALSE will result in warnings
 #'   being posted.
 #'
 #' @param sslVerify Boolean. This argument defaults to TRUE and is optional. In
@@ -43,30 +43,27 @@
 #'
 
 logoutBF = function(suppress = TRUE, sslVerify = TRUE) {
-  #return(suppressWarnings(as.list(jsonlite::fromJSON(RCurl::postForm("https://identitysso.betfair.com/api/keepAlive", .opts=list(httpheader=headersPostLogin, ssl.verifypeer = sslVerify))))))
 
   # Read Environment variables for authorisation details
   product <- Sys.getenv('product')
   token <- Sys.getenv('token')
 
-  headers <- list(
-    'Accept' = 'application/json', 'X-Application' = product, 'X-Authentication' = token, 'Content-Type' = 'application/json'
-  )
-
   if (suppress)
     logout <-
-      suppressWarnings(as.list(jsonlite::fromJSON(
-        RCurl::postForm(
-          "https://identitysso.betfair.com/api/logout", .opts = list(httpheader =
-                                                                       headers, ssl.verifypeer = sslVerify)
-        )
-      )))
+      suppressWarnings(logout <- as.list(httr::content(
+        httr::POST(url = "https://identitysso.betfair.com/api/logout",
+                   httr::add_headers(Accept = "application/json",
+                                     "X-Application" = product,
+                                     "X-Authentication" = token)), as = "text")
+
+      ))
   else
-    (logout = as.list(jsonlite::fromJSON(
-      RCurl::postForm(
-        "https://identitysso.betfair.com/api/logout", .opts = list(httpheader =
-                                                                     headers, ssl.verifypeer = sslVerify)
-      )
-    )))
+    (logout <- as.list(httr::content(
+      httr::POST(url = "https://identitysso.betfair.com/api/logout",
+                 httr::add_headers(Accept = "application/json",
+                 "X-Application" = product,
+                 "X-Authentication" = token)), as = "text")
+
+    ))
   return(paste0(logout$status,":",logout$error))
 }


### PR DESCRIPTION
Move from RCurl to httr for cancelOrders, listCompetitions, listEventTypes, listEvents, listMarketTypes, listVenues, logoutBF, replaceOrders, updateOrders

Basic testing conducted only. No changes made other than conversion to httr.

This closes issues #24 and #11.