### PR TITLE
Modify getAccountStatement so that it can retrieve more than 100 records

### DIFF
--- a/R/getAccountStatement.R
+++ b/R/getAccountStatement.R
@@ -8,14 +8,16 @@
 #'
 #' @param localeString String. The language to be used where applicable. If not
 #'   specified, the customer account default is returned. Default is NULL.
-#'   Optional.
+#'   This function will convert NULL to 0 as it requires a value to increment in
+#'   the loop where there are more than 100 records. Optional.
 #'
 #' @param fromRecordValue int. Specifies the first record that will be returned.
 #'   Records start at index zero. Default parameter value is NULL, which Betfair
 #'   interprets as 0. Optional.
 #'
 #' @param recordCountValue int. Specifies the maximum number of records to be
-#'   returned. Note that there is a page size limit of 100.
+#'   returned. Note that there is a page size limit of 100. If the number is
+#'   greater than 100 then the function will loop to gather all records. Optional
 #'
 #' @param toDate Datetime (ISO 8601 format). Lower bound of date range
 #'   (inclusive). Default value is NULL, which means that the oldest available
@@ -68,7 +70,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Return the latest 100 records:
+#' # Return all available records:
 #' getAccountStatement()
 #' }
 #'


### PR DESCRIPTION
I've updated this so that it can retrieve all available records - which is the default. The code is not pretty. The data returned from the API is messy as one of the columns is a data.frame (legacyData) and it is not possible to rbind the retrieved data.frames together. For some reason it is possible to cbind them once they've been transposed. In addition, the legacyData columns are not in a consistent order and it is necessary to reorder them before combining them. 
The default behaviour works as expected, also using fromRecordValue and recordCountValue works. The fromDate and toDate fields are only used in a few specific cases and I've not tested them specifically.
It would be helpful if someone else could test this thoroughly as I've been working around in circles all day on trying to make this work. 
