### PR TITLE
Minor fix to prevent warnings: "No encoding supplied: defaulting to UTF-8."

### DIFF
--- a/R/cancelOrders.R
+++ b/R/cancelOrders.R
@@ -129,7 +129,7 @@ cancelOrders <-
                  body = cancelOrderOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     cancelOrders <- jsonlite::fromJSON(cancelOrders)
 

--- a/R/listCompetitions.R
+++ b/R/listCompetitions.R
@@ -205,7 +205,7 @@ listCompetitions <-
                  body = listCompetitionsOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listCompetitions <- jsonlite::fromJSON(listCompetitions)
 

--- a/R/listCompetitions.R
+++ b/R/listCompetitions.R
@@ -23,12 +23,14 @@
 #'   Optional. Default is NULL.
 #'
 #' @param fromDate The start date from which to return matching competitions.
-#'   Format is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to
+#'   Format is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to
 #'   current system date and time minus 2 hours (to allow searching of all
 #'   in-play football matches).
 #'
 #' @param toDate The end date to stop returning matching competitions. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to competitions that are associated
@@ -121,8 +123,8 @@
 
 listCompetitions <-
   function(eventTypeIds , marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/listCountries.R
+++ b/R/listCountries.R
@@ -27,12 +27,14 @@
 #'   Optional. Default is NULL.
 #'
 #' @param fromDate The start date from which to return matching countries.
-#'   Format is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to
+#'   Format is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to
 #'   current system date and time minus 2 hours (to allow searching of all
 #'   in-play football matches).
 #'
 #' @param toDate The end date to stop returning matching countries. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to countries that are associated
@@ -125,8 +127,8 @@
 
 listCountries <-
   function(eventTypeIds , marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/listCurrentOrders.R
+++ b/R/listCurrentOrders.R
@@ -134,7 +134,7 @@ listCurrentOrders <-
                  body = listOrderOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listOrder <- jsonlite::fromJSON(listOrder)
 

--- a/R/listEventTypes.R
+++ b/R/listEventTypes.R
@@ -201,7 +201,7 @@ listEventTypes <-
                  body = listEventTypesOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listEventTypes <- jsonlite::fromJSON(listEventTypes)
 

--- a/R/listEventTypes.R
+++ b/R/listEventTypes.R
@@ -21,12 +21,14 @@
 #'   Default is NULL.
 #'
 #' @param fromDate The start date from which to return matching events. Format
-#'   is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to current
+#'   is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to current
 #'   system date and time minus 2 hours (to allow searching of all in-play
 #'   football matches).
 #'
 #' @param toDate The end date to stop returning matching events. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to event types that are associated
@@ -118,8 +120,8 @@
 
 listEventTypes <-
   function(eventTypeIds = NULL, marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/listEvents.R
+++ b/R/listEvents.R
@@ -26,12 +26,14 @@
 #'   is NULL.
 #'
 #' @param fromDate The start date from which to return matching events. Format
-#'   is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to current
+#'   is \%Y-\%m-\%dT\%TZ. Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to current
 #'   system date and time minus 2 hours (to allow searching of all in-play
 #'   football matches).
 #'
 #' @param toDate The end date to stop returning matching events. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ. Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to events that are associated with

--- a/R/listEvents.R
+++ b/R/listEvents.R
@@ -26,13 +26,13 @@
 #'   is NULL.
 #'
 #' @param fromDate The start date from which to return matching events. Format
-#'   is \%Y-\%m-\%dT\%TZ. Times must be submitted in UTC as this is what is used
+#'   is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
 #'   by Betfair. Optional. If not defined, it defaults to current
 #'   system date and time minus 2 hours (to allow searching of all in-play
 #'   football matches).
 #'
 #' @param toDate The end date to stop returning matching events. Format is
-#'   \%Y-\%m-\%dT\%TZ. Times must be submitted in UTC as this is what is used
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
 #'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'

--- a/R/listEvents.R
+++ b/R/listEvents.R
@@ -217,7 +217,7 @@ listEvents <-
                  body = listEventsOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listEvents <- jsonlite::fromJSON(listEvents)
 

--- a/R/listEvents.R
+++ b/R/listEvents.R
@@ -134,8 +134,8 @@
 
 listEvents <-
   function(eventTypeIds, marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/listMarketBook.R
+++ b/R/listMarketBook.R
@@ -164,7 +164,7 @@ listMarketBook <- function(marketIds, priceData , orderProjection = NULL,
                body = listMarketBookOps,
                httr::add_headers(Accept = "application/json",
                                  "X-Application" = product,
-                                 "X-Authentication" = token)), as = "text")
+                                 "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
   listMarketBook <- jsonlite::fromJSON(listMarketBook)
 

--- a/R/listMarketCatalogue.R
+++ b/R/listMarketCatalogue.R
@@ -34,12 +34,14 @@
 #'   defined, defaults to 200.
 #'
 #' @param fromDate The start date from which to return matching events. Format
-#'   is \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to current system
+#'   is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to current system
 #'   date and time minus 2 hours (to allow searching of all in-play football
 #'   matches).
 #'
 #' @param toDate The end date to stop returning matching events. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to markets that are associated with
@@ -158,15 +160,18 @@
 #'
 
 listMarketCatalogue <-
-  function(eventTypeIds, marketTypeCodes, maxResults = "200", fromDate = (format(Sys.time() -
-                                                                                   7200, "%Y-%m-%dT%TZ")), toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
-           eventIds = NULL,competitionIds = NULL,marketIds =
-             NULL,marketCountries = NULL,venues = NULL,bspOnly = NULL,turnInPlayEnabled =
-             NULL,inPlayOnly = NULL,marketBettingTypes = NULL,
-           withOrders = NULL,marketSort = NULL,marketProjection =
+  function(eventTypeIds, marketTypeCodes, maxResults = "200",
+          fromDate = (format(Sys.time() - 7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+          toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
+          eventIds = NULL,competitionIds = NULL,marketIds = NULL,
+          marketCountries = NULL,venues = NULL,bspOnly = NULL,
+          turnInPlayEnabled = NULL,inPlayOnly = NULL,
+          marketBettingTypes = NULL, withOrders = NULL,
+          marketSort = NULL,marketProjection =
              c(
                "COMPETITION", "EVENT", "EVENT_TYPE", "RUNNER_DESCRIPTION", "RUNNER_METADATA", "MARKET_START_TIME"
-             ),textQuery = NULL, suppress = FALSE, sslVerify = TRUE) {
+             ),
+          textQuery = NULL, suppress = FALSE, sslVerify = TRUE) {
     options(stringsAsFactors = FALSE)
 
     listMarketCatalogueOps <-

--- a/R/listMarketCatalogue.R
+++ b/R/listMarketCatalogue.R
@@ -247,7 +247,7 @@ listMarketCatalogue <-
                  body = listMarketCatalogueOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listMarketCat <- jsonlite::fromJSON(listMarketCat)
 

--- a/R/listMarketTypes.R
+++ b/R/listMarketTypes.R
@@ -203,7 +203,7 @@ listMarketTypes <-
                  body = listMarketTypesOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listMarketTypes <- jsonlite::fromJSON(listMarketTypes)
 

--- a/R/listMarketTypes.R
+++ b/R/listMarketTypes.R
@@ -22,12 +22,14 @@
 #'   Optional. Default is NULL.
 #'
 #' @param fromDate The start date from which to return matching market types.
-#'   Format is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to
+#'   Format is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to
 #'   current system date and time minus 2 hours (to allow searching of all
 #'   in-play football matches).
 #'
 #' @param toDate The end date to stop returning matching market types. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to market types that are associated
@@ -120,8 +122,8 @@
 
 listMarketTypes <-
   function(eventTypeIds , marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/listVenues.R
+++ b/R/listVenues.R
@@ -198,7 +198,7 @@ listVenues <-
                  body = listVenuesOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     listVenues <- jsonlite::fromJSON(listVenues)
 

--- a/R/listVenues.R
+++ b/R/listVenues.R
@@ -18,12 +18,14 @@
 #'   obtained via \code{\link{listMarketTypes}}. Optional. Default is NULL.
 #'
 #' @param fromDate The start date from which to return matching venues.
-#'   Format is \%Y-\%m-\%dT\%TZ. Optional. If not defined, it defaults to
+#'   Format is \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined, it defaults to
 #'   current system date and time minus 2 hours (to allow searching of all
 #'   in-play football matches).
 #'
 #' @param toDate The end date to stop returning matching venues. Format is
-#'   \%Y-\%m-\%dT\%TZ. Optional. If not defined defaults to the current system
+#'   \%Y-\%m-\%dT\%TZ, tz = "UTC". Times must be submitted in UTC as this is what is used
+#'   by Betfair. Optional. If not defined defaults to the current system
 #'   date and time plus 24 hours.
 #'
 #' @param eventIds vector <String>. Restrict to venues that are associated
@@ -115,8 +117,8 @@
 
 listVenues <-
   function(eventTypeIds = c("7") , marketTypeCodes=NULL,
-           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ")),
-           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ")),
+           fromDate = (format(Sys.time() -7200, "%Y-%m-%dT%TZ", tz = "UTC")),
+           toDate = (format(Sys.time() + 86400, "%Y-%m-%dT%TZ", tz = "UTC")),
            eventIds = NULL, competitionIds = NULL, marketIds =NULL,
            marketCountries = NULL, venues = NULL, bspOnly = NULL,
            turnInPlayEnabled = NULL, inPlayOnly = NULL, marketBettingTypes = NULL,

--- a/R/placeOrders.R
+++ b/R/placeOrders.R
@@ -279,7 +279,7 @@ placeOrders <-
                  body = placeOrdersOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     placeOrders <- jsonlite::fromJSON(placeOrders)
 

--- a/R/replaceOrders.R
+++ b/R/replaceOrders.R
@@ -95,7 +95,7 @@ replaceOrders <- function(marketId ,betId, newPrice, suppress = FALSE, sslVerify
                body = replaceOrderOps,
                httr::add_headers(Accept = "application/json",
                                  "X-Application" = product,
-                                 "X-Authentication" = token)), as = "text")
+                                 "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
   replaceOrder <- jsonlite::fromJSON(replaceOrder)
 

--- a/R/updateOrders.R
+++ b/R/updateOrders.R
@@ -97,7 +97,7 @@ updateOrders <-
                  body = updateOrderOps,
                  httr::add_headers(Accept = "application/json",
                                    "X-Application" = product,
-                                   "X-Authentication" = token)), as = "text")
+                                   "X-Authentication" = token)), as = "text", encoding = "UTF-8")
 
     updateOrder <- jsonlite::fromJSON(updateOrder)
 


### PR DESCRIPTION
A minor fix to prevent warnings about encoding by explicitly passing encoding = "UTF-8" to the API. Functions impacted are: cancelOrders, listCompetitions, listCurrentOrders, listEventTypes, listEvents, listMarketBook, listMarketCatalogue, listMarketTypes, listVenues, placeOrders, replaceOrders, updateOrders